### PR TITLE
[feat/#9] jwt를 이용한 로그인, 회원가입 기능 구현 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 .DS_Store
 
 application.yml
+data

--- a/build.gradle
+++ b/build.gradle
@@ -26,10 +26,18 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	// jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3"
+services:
+  redis:
+    container_name: redis
+    image: redis:latest
+    ports:
+      - 6379:6379
+    volumes:
+      - ./redis/data:/data
+    labels:
+      - "name=redis"
+      - "mode=standalone"
+    restart: always
+    command: redis-server

--- a/src/main/java/com/aiary/aiary/domain/diary/controller/DiaryController.java
+++ b/src/main/java/com/aiary/aiary/domain/diary/controller/DiaryController.java
@@ -3,6 +3,7 @@ package com.aiary.aiary.domain.diary.controller;
 
 import com.aiary.aiary.domain.diary.dto.request.DiaryCreateRequest;
 import com.aiary.aiary.domain.diary.service.DiaryService;
+import com.aiary.aiary.domain.user.entity.UserDetail;
 import com.aiary.aiary.global.result.ResultCode;
 import com.aiary.aiary.global.result.ResultResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,6 +12,7 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
@@ -25,14 +27,14 @@ public class DiaryController {
 
     private final DiaryService diaryService;
 
-    @Operation(summary = "일기등록")
+    @Operation(summary = "일기 등록")
     @PostMapping
-    public ResponseEntity<ResultResponse> createDiary(@Valid @RequestBody DiaryCreateRequest createRequest){
-        diaryService.createDiary(createRequest);
+    public ResponseEntity<ResultResponse> createDiary(@AuthenticationPrincipal UserDetail user,  @Valid @RequestBody DiaryCreateRequest createRequest){
+        diaryService.createDiary(user.getUser(), createRequest);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.DIARY_CREATE_SUCCESS));
     }
 
-    @Operation(summary = "일기 id 별 조회")
+    @Operation(summary = "일기 삭제")
     @DeleteMapping("/{diaryId}")
     public ResponseEntity<ResultResponse> deleteDiary(@PathVariable Long diaryId){
         diaryService.deleteDiary(diaryId);
@@ -41,10 +43,10 @@ public class DiaryController {
 
     @Operation(summary = "일기 월 별 조회")
     @GetMapping
-    public ResponseEntity<ResultResponse> findMonthlyDiary(@RequestParam("user_id") Long userId,
+    public ResponseEntity<ResultResponse> findMonthlyDiary(@AuthenticationPrincipal UserDetail user,
                                                            @RequestParam("diary_date")
                                                            @DateTimeFormat(pattern = "yyyy-MM") Date diaryDate){
         return ResponseEntity.ok(ResultResponse
-                .of(ResultCode.DIARY_READ_SUCCESS, diaryService.findMonthlyDiary(userId, diaryDate)));
+                .of(ResultCode.DIARY_READ_SUCCESS, diaryService.findMonthlyDiary(user.getUser().getId(), diaryDate)));
     }
 }

--- a/src/main/java/com/aiary/aiary/domain/diary/controller/DiaryController.java
+++ b/src/main/java/com/aiary/aiary/domain/diary/controller/DiaryController.java
@@ -29,7 +29,7 @@ public class DiaryController {
 
     @Operation(summary = "일기 등록")
     @PostMapping
-    public ResponseEntity<ResultResponse> createDiary(@AuthenticationPrincipal UserDetail user,  @Valid @RequestBody DiaryCreateRequest createRequest){
+    public ResponseEntity<ResultResponse> createDiary(@AuthenticationPrincipal UserDetail user, @Valid @RequestBody DiaryCreateRequest createRequest){
         diaryService.createDiary(user.getUser(), createRequest);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.DIARY_CREATE_SUCCESS));
     }

--- a/src/main/java/com/aiary/aiary/domain/diary/controller/DiaryController.java
+++ b/src/main/java/com/aiary/aiary/domain/diary/controller/DiaryController.java
@@ -5,6 +5,8 @@ import com.aiary.aiary.domain.diary.dto.request.DiaryCreateRequest;
 import com.aiary.aiary.domain.diary.service.DiaryService;
 import com.aiary.aiary.global.result.ResultCode;
 import com.aiary.aiary.global.result.ResultResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 import java.util.Date;
 
+@Tag(name = "Diary", description = "일기 API")
 @Controller
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @RequestMapping("/api/diaries")
@@ -22,18 +25,21 @@ public class DiaryController {
 
     private final DiaryService diaryService;
 
+    @Operation(summary = "일기등록")
     @PostMapping
     public ResponseEntity<ResultResponse> createDiary(@Valid @RequestBody DiaryCreateRequest createRequest){
         diaryService.createDiary(createRequest);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.DIARY_CREATE_SUCCESS));
     }
-    
+
+    @Operation(summary = "일기 id 별 조회")
     @DeleteMapping("/{diaryId}")
     public ResponseEntity<ResultResponse> deleteDiary(@PathVariable Long diaryId){
         diaryService.deleteDiary(diaryId);
         return ResponseEntity.ok(ResultResponse.of(ResultCode.DIARY_DELETE_SUCCESS));
     }
 
+    @Operation(summary = "일기 월 별 조회")
     @GetMapping
     public ResponseEntity<ResultResponse> findMonthlyDiary(@RequestParam("user_id") Long userId,
                                                            @RequestParam("diary_date")

--- a/src/main/java/com/aiary/aiary/domain/diary/dto/request/DiaryCreateRequest.java
+++ b/src/main/java/com/aiary/aiary/domain/diary/dto/request/DiaryCreateRequest.java
@@ -13,9 +13,6 @@ import java.time.LocalDate;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class DiaryCreateRequest {
 
-    @NotNull(message = "사용자 id는 필수 입니다.")
-    private Long userId;
-
     @NotBlank(message = "일기 제목은 필수 입니다.")
     private String title;
 

--- a/src/main/java/com/aiary/aiary/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/aiary/aiary/domain/diary/service/DiaryService.java
@@ -7,7 +7,6 @@ import com.aiary.aiary.domain.diary.entity.Diary;
 import com.aiary.aiary.domain.diary.exception.DiaryNotFoundException;
 import com.aiary.aiary.domain.diary.repository.DiaryRepository;
 import com.aiary.aiary.domain.user.entity.User;
-import com.aiary.aiary.domain.user.repository.UserRepository;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,13 +20,10 @@ import java.util.List;
 public class DiaryService {
 
     private final DiaryRepository diaryRepository;
-    private final UserRepository userRepository ;
     private final DiaryMapper diaryMapper;
 
-    public void createDiary(DiaryCreateRequest diaryCreateRequest){
-        User findUser = userRepository.findById(diaryCreateRequest.getUserId()).orElseThrow(IllegalAccessError::new);
-
-        Diary newDiary = diaryMapper.toCreateRequestDTO(diaryCreateRequest, findUser);
+    public void createDiary(User user, DiaryCreateRequest diaryCreateRequest){
+        Diary newDiary = diaryMapper.toCreateRequestDTO(diaryCreateRequest, user);
         diaryRepository.save(newDiary);
     }
   

--- a/src/main/java/com/aiary/aiary/domain/user/controller/UserController.java
+++ b/src/main/java/com/aiary/aiary/domain/user/controller/UserController.java
@@ -47,4 +47,10 @@ public class UserController {
         }
         return ResponseEntity.ok(ResultResponse.of(USER_EMAIL_NOT_DUPLICATED, false));
     }
+
+    @PostMapping("/login")
+    public ResponseEntity<JwtToken> login(@RequestBody UserLoginReq userLoginReq) {
+        JwtToken token = loginService.login(userLoginReq.getEmail(), userLoginReq.getPassword());
+        return ResponseEntity.ok(token);
+    }
 }

--- a/src/main/java/com/aiary/aiary/domain/user/controller/UserController.java
+++ b/src/main/java/com/aiary/aiary/domain/user/controller/UserController.java
@@ -1,0 +1,50 @@
+package com.aiary.aiary.domain.user.controller;
+
+import com.aiary.aiary.domain.user.dto.request.UserJoinReq;
+import com.aiary.aiary.domain.user.dto.request.UserLoginReq;
+import com.aiary.aiary.domain.user.exception.UserDuplicatedException;
+import com.aiary.aiary.domain.user.mapper.UserMapper;
+import com.aiary.aiary.domain.user.service.LoginService;
+import com.aiary.aiary.domain.user.service.UserService;
+import com.aiary.aiary.global.jwt.JwtToken;
+import com.aiary.aiary.global.result.ResultCode;
+import com.aiary.aiary.global.result.ResultResponse;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+import static com.aiary.aiary.global.result.ResultCode.USER_EMAIL_NOT_DUPLICATED;
+import static com.aiary.aiary.global.result.ResultCode.USER_REGISTRATION_SUCCESS;
+
+@RestController
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@RequestMapping("/api/users")
+public class UserController {
+    private final UserService userService;
+    private final UserMapper userMapper;
+    private final LoginService loginService;
+
+
+    @PostMapping("/join")
+    public ResponseEntity<ResultResponse> join(
+            @RequestBody @Valid UserJoinReq userJoinReq) {
+        if (userService.isDuplicatedEmail(userJoinReq.getEmail())) {
+            throw new UserDuplicatedException();
+        }
+        userService.register(userJoinReq);
+        return ResponseEntity.ok(ResultResponse.of(USER_REGISTRATION_SUCCESS));
+    }
+
+    @GetMapping("/duplicated/{email}")
+    public ResponseEntity<ResultResponse> isDuplicatedEmail(@PathVariable String email) {
+        boolean isDuplicated = userService.isDuplicatedEmail(email);
+
+        if (isDuplicated) {
+            return ResponseEntity.ok(ResultResponse.of(ResultCode.USER_EMAIL_DUPLICATED, true));
+        }
+        return ResponseEntity.ok(ResultResponse.of(USER_EMAIL_NOT_DUPLICATED, false));
+    }
+}

--- a/src/main/java/com/aiary/aiary/domain/user/controller/UserController.java
+++ b/src/main/java/com/aiary/aiary/domain/user/controller/UserController.java
@@ -16,8 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
-import static com.aiary.aiary.global.result.ResultCode.USER_EMAIL_NOT_DUPLICATED;
-import static com.aiary.aiary.global.result.ResultCode.USER_REGISTRATION_SUCCESS;
+import static com.aiary.aiary.global.result.ResultCode.*;
 
 @RestController
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
@@ -49,8 +48,8 @@ public class UserController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<JwtToken> login(@RequestBody UserLoginReq userLoginReq) {
+    public ResponseEntity<ResultResponse> login(@RequestBody UserLoginReq userLoginReq) {
         JwtToken token = loginService.login(userLoginReq.getEmail(), userLoginReq.getPassword());
-        return ResponseEntity.ok(token);
+        return ResponseEntity.ok(ResultResponse.of(USER_LOGIN_SUCCESS, token));
     }
 }

--- a/src/main/java/com/aiary/aiary/domain/user/controller/UserController.java
+++ b/src/main/java/com/aiary/aiary/domain/user/controller/UserController.java
@@ -2,13 +2,15 @@ package com.aiary.aiary.domain.user.controller;
 
 import com.aiary.aiary.domain.user.dto.request.UserJoinReq;
 import com.aiary.aiary.domain.user.dto.request.UserLoginReq;
+import com.aiary.aiary.domain.user.dto.request.UserTokenReq;
 import com.aiary.aiary.domain.user.exception.UserDuplicatedException;
-import com.aiary.aiary.domain.user.mapper.UserMapper;
 import com.aiary.aiary.domain.user.service.LoginService;
 import com.aiary.aiary.domain.user.service.UserService;
 import com.aiary.aiary.global.jwt.JwtToken;
 import com.aiary.aiary.global.result.ResultCode;
 import com.aiary.aiary.global.result.ResultResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,15 +20,16 @@ import javax.validation.Valid;
 
 import static com.aiary.aiary.global.result.ResultCode.*;
 
+@Tag(name = "User", description = "사용자 API")
 @RestController
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 @RequestMapping("/api/users")
 public class UserController {
     private final UserService userService;
-    private final UserMapper userMapper;
     private final LoginService loginService;
 
 
+    @Operation(summary = "회원가입")
     @PostMapping("/join")
     public ResponseEntity<ResultResponse> join(
             @RequestBody @Valid UserJoinReq userJoinReq) {
@@ -37,6 +40,7 @@ public class UserController {
         return ResponseEntity.ok(ResultResponse.of(USER_REGISTRATION_SUCCESS));
     }
 
+    @Operation(summary = "이메일 중복확인")
     @GetMapping("/duplicated/{email}")
     public ResponseEntity<ResultResponse> isDuplicatedEmail(@PathVariable String email) {
         boolean isDuplicated = userService.isDuplicatedEmail(email);
@@ -47,15 +51,24 @@ public class UserController {
         return ResponseEntity.ok(ResultResponse.of(USER_EMAIL_NOT_DUPLICATED, false));
     }
 
+    @Operation(summary = "로그인")
     @PostMapping("/login")
     public ResponseEntity<ResultResponse> login(@RequestBody UserLoginReq userLoginReq) {
         JwtToken token = loginService.login(userLoginReq.getEmail(), userLoginReq.getPassword());
         return ResponseEntity.ok(ResultResponse.of(USER_LOGIN_SUCCESS, token));
     }
 
+    @Operation(summary = "로그아웃")
     @PostMapping("/logout")
-    public ResponseEntity<ResultResponse> logout(@RequestBody JwtToken token) {
-        loginService.logout(token);
+    public ResponseEntity<ResultResponse> logout(@RequestBody UserTokenReq userTokenReq) {
+        loginService.logout(userTokenReq);
         return ResponseEntity.ok(ResultResponse.of(USER_LOGOUT_SUCCESS));
+    }
+
+    @Operation(summary = "토큰 재발급")
+    @PostMapping("/reissue")
+    public ResponseEntity<ResultResponse> reissue(@RequestBody UserTokenReq userTokenReq) {
+        JwtToken newToken = loginService.reissue(userTokenReq);
+        return ResponseEntity.ok(ResultResponse.of(USER_REISSUE_SUCCESS, newToken));
     }
 }

--- a/src/main/java/com/aiary/aiary/domain/user/controller/UserController.java
+++ b/src/main/java/com/aiary/aiary/domain/user/controller/UserController.java
@@ -42,7 +42,7 @@ public class UserController {
 
     @Operation(summary = "이메일 중복확인")
     @GetMapping("/duplicated/{email}")
-    public ResponseEntity<ResultResponse> isDuplicatedEmail(@PathVariable String email) {
+    public ResponseEntity<ResultResponse> checkEmail(@PathVariable String email) {
         boolean isDuplicated = userService.isDuplicatedEmail(email);
 
         if (isDuplicated) {
@@ -54,7 +54,7 @@ public class UserController {
     @Operation(summary = "로그인")
     @PostMapping("/login")
     public ResponseEntity<ResultResponse> login(@RequestBody UserLoginReq userLoginReq) {
-        JwtToken token = loginService.login(userLoginReq.getEmail(), userLoginReq.getPassword());
+        JwtToken token = loginService.login(userLoginReq);
         return ResponseEntity.ok(ResultResponse.of(USER_LOGIN_SUCCESS, token));
     }
 

--- a/src/main/java/com/aiary/aiary/domain/user/controller/UserController.java
+++ b/src/main/java/com/aiary/aiary/domain/user/controller/UserController.java
@@ -3,11 +3,10 @@ package com.aiary.aiary.domain.user.controller;
 import com.aiary.aiary.domain.user.dto.request.UserJoinReq;
 import com.aiary.aiary.domain.user.dto.request.UserLoginReq;
 import com.aiary.aiary.domain.user.dto.request.UserTokenReq;
-import com.aiary.aiary.domain.user.exception.UserDuplicatedException;
-import com.aiary.aiary.domain.user.service.LoginService;
+import com.aiary.aiary.domain.user.service.AuthService;
 import com.aiary.aiary.domain.user.service.UserService;
+import com.aiary.aiary.domain.user.validator.UserValidator;
 import com.aiary.aiary.global.jwt.JwtToken;
-import com.aiary.aiary.global.result.ResultCode;
 import com.aiary.aiary.global.result.ResultResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -26,49 +25,50 @@ import static com.aiary.aiary.global.result.ResultCode.*;
 @RequestMapping("/api/users")
 public class UserController {
     private final UserService userService;
-    private final LoginService loginService;
+    private final AuthService authService;
+    private final UserValidator userValidator;
 
 
     @Operation(summary = "회원가입")
     @PostMapping("/join")
-    public ResponseEntity<ResultResponse> join(
+    public ResponseEntity<ResultResponse> signup(
             @RequestBody @Valid UserJoinReq userJoinReq) {
-        if (userService.isDuplicatedEmail(userJoinReq.getEmail())) {
-            throw new UserDuplicatedException();
-        }
+        userValidator.isDuplicatedEmail(userJoinReq);
         userService.register(userJoinReq);
         return ResponseEntity.ok(ResultResponse.of(USER_REGISTRATION_SUCCESS));
     }
 
-    @Operation(summary = "이메일 중복확인")
-    @GetMapping("/duplicated/{email}")
-    public ResponseEntity<ResultResponse> checkEmail(@PathVariable String email) {
-        boolean isDuplicated = userService.isDuplicatedEmail(email);
 
-        if (isDuplicated) {
-            return ResponseEntity.ok(ResultResponse.of(ResultCode.USER_EMAIL_DUPLICATED, true));
-        }
-        return ResponseEntity.ok(ResultResponse.of(USER_EMAIL_NOT_DUPLICATED, false));
-    }
+//    @Operation(summary = "이메일 중복확인")
+//    @GetMapping("/duplicated/{email}")
+//    public ResponseEntity<ResultResponse> checkEmail(@PathVariable String email) {
+//        boolean isDuplicated = userService.isDuplicatedEmail(email);
+//
+//        if (isDuplicated) {
+//            return ResponseEntity.ok(ResultResponse.of(ResultCode.USER_EMAIL_DUPLICATED, true));
+//        }
+//        return ResponseEntity.ok(ResultResponse.of(USER_EMAIL_NOT_DUPLICATED, false));
+//    }
+
 
     @Operation(summary = "로그인")
     @PostMapping("/login")
-    public ResponseEntity<ResultResponse> login(@RequestBody UserLoginReq userLoginReq) {
-        JwtToken token = loginService.login(userLoginReq);
+    public ResponseEntity<ResultResponse> login(@RequestBody @Valid UserLoginReq userLoginReq) {
+        JwtToken token = authService.login(userLoginReq);
         return ResponseEntity.ok(ResultResponse.of(USER_LOGIN_SUCCESS, token));
     }
 
     @Operation(summary = "로그아웃")
     @PostMapping("/logout")
-    public ResponseEntity<ResultResponse> logout(@RequestBody UserTokenReq userTokenReq) {
-        loginService.logout(userTokenReq);
+    public ResponseEntity<ResultResponse> logout(@RequestBody @Valid UserTokenReq userTokenReq) {
+        authService.logout(userTokenReq);
         return ResponseEntity.ok(ResultResponse.of(USER_LOGOUT_SUCCESS));
     }
 
     @Operation(summary = "토큰 재발급")
     @PostMapping("/reissue")
-    public ResponseEntity<ResultResponse> reissue(@RequestBody UserTokenReq userTokenReq) {
-        JwtToken newToken = loginService.reissue(userTokenReq);
+    public ResponseEntity<ResultResponse> reissue(@RequestBody @Valid UserTokenReq userTokenReq) {
+        JwtToken newToken = authService.reissue(userTokenReq);
         return ResponseEntity.ok(ResultResponse.of(USER_REISSUE_SUCCESS, newToken));
     }
 }

--- a/src/main/java/com/aiary/aiary/domain/user/controller/UserController.java
+++ b/src/main/java/com/aiary/aiary/domain/user/controller/UserController.java
@@ -52,4 +52,10 @@ public class UserController {
         JwtToken token = loginService.login(userLoginReq.getEmail(), userLoginReq.getPassword());
         return ResponseEntity.ok(ResultResponse.of(USER_LOGIN_SUCCESS, token));
     }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ResultResponse> logout(@RequestBody JwtToken token) {
+        loginService.logout(token);
+        return ResponseEntity.ok(ResultResponse.of(USER_LOGOUT_SUCCESS));
+    }
 }

--- a/src/main/java/com/aiary/aiary/domain/user/dto/request/UserJoinReq.java
+++ b/src/main/java/com/aiary/aiary/domain/user/dto/request/UserJoinReq.java
@@ -1,0 +1,26 @@
+package com.aiary.aiary.domain.user.dto.request;
+
+import lombok.*;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserJoinReq {
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    @Email(message = "이메일 형식에 맞지 않습니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    @Pattern(
+            message = "대소문자와 숫자, 특수문자를 포함한 8자 이상 16자 이하의 비밀번호를 입력해야 합니다.",
+            regexp = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[@#!~$%^&-+=()])(?=\\S+$).{8,16}$")
+    private String password;
+
+    @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+    private String nickname;
+}

--- a/src/main/java/com/aiary/aiary/domain/user/dto/request/UserJoinReq.java
+++ b/src/main/java/com/aiary/aiary/domain/user/dto/request/UserJoinReq.java
@@ -8,8 +8,8 @@ import javax.validation.constraints.Pattern;
 
 @Getter
 @Builder
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserJoinReq {
     @NotBlank(message = "이메일은 필수 입력 값입니다.")
     @Email(message = "이메일 형식에 맞지 않습니다.")

--- a/src/main/java/com/aiary/aiary/domain/user/dto/request/UserLoginReq.java
+++ b/src/main/java/com/aiary/aiary/domain/user/dto/request/UserLoginReq.java
@@ -8,8 +8,8 @@ import javax.validation.constraints.Pattern;
 
 @Getter
 @Builder
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserLoginReq {
     @NotBlank(message = "이메일은 필수 입력 값입니다.")
     @Email(message = "이메일 형식에 맞지 않습니다.")

--- a/src/main/java/com/aiary/aiary/domain/user/dto/request/UserLoginReq.java
+++ b/src/main/java/com/aiary/aiary/domain/user/dto/request/UserLoginReq.java
@@ -1,0 +1,22 @@
+package com.aiary.aiary.domain.user.dto.request;
+
+import lombok.*;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserLoginReq {
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    @Email(message = "이메일 형식에 맞지 않습니다.")
+    private String email;
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    @Pattern(
+            message = "대소문자와 숫자, 특수문자를 포함한 8자 이상 16자 이하의 비밀번호를 입력해야 합니다.",
+            regexp = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[@#!~$%^&-+=()])(?=\\S+$).{8,16}$")
+    private String password;
+}

--- a/src/main/java/com/aiary/aiary/domain/user/dto/request/UserTokenReq.java
+++ b/src/main/java/com/aiary/aiary/domain/user/dto/request/UserTokenReq.java
@@ -6,8 +6,8 @@ import javax.validation.constraints.NotBlank;
 
 @Getter
 @Builder
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserTokenReq {
     @NotBlank(message = "accessToken 을 입력해주세요.")
     private String accessToken;

--- a/src/main/java/com/aiary/aiary/domain/user/dto/request/UserTokenReq.java
+++ b/src/main/java/com/aiary/aiary/domain/user/dto/request/UserTokenReq.java
@@ -1,0 +1,17 @@
+package com.aiary.aiary.domain.user.dto.request;
+
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserTokenReq {
+    @NotBlank(message = "accessToken 을 입력해주세요.")
+    private String accessToken;
+
+    @NotBlank(message = "refreshToken 을 입력해주세요.")
+    private String refreshToken;
+}

--- a/src/main/java/com/aiary/aiary/domain/user/entity/Role.java
+++ b/src/main/java/com/aiary/aiary/domain/user/entity/Role.java
@@ -1,0 +1,14 @@
+package com.aiary.aiary.domain.user.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+    GUEST("ROLE_GUEST", "비회원"),
+    USER("ROLE_USER", "회원");
+
+    private final String key;
+    private final String title;
+}

--- a/src/main/java/com/aiary/aiary/domain/user/entity/SessionUser.java
+++ b/src/main/java/com/aiary/aiary/domain/user/entity/SessionUser.java
@@ -1,0 +1,55 @@
+package com.aiary.aiary.domain.user.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SessionUser implements UserDetails {
+    private User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+
+        return new ArrayList<>();
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/aiary/aiary/domain/user/entity/User.java
+++ b/src/main/java/com/aiary/aiary/domain/user/entity/User.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -31,7 +32,7 @@ public class User extends BaseEntity {
     @Column(nullable = false, length = 250)
     private String password;
 
-    @Column(nullable = false, length = 500)
+    @Column(length = 500)
     private String thema;   // 테마 (변경될 수 있음)
 
     @Column(name = "is_active")
@@ -41,14 +42,18 @@ public class User extends BaseEntity {
     private List<Diary> diaries = new ArrayList<>();
 
     @Builder
-    private User(String email, String nickname, String password, String thema) {
+    private User(String email, String nickname, String password) {
         this.email = email;
         this.nickname = nickname;
         this.password = password;
-        this.thema = thema;
+        this.thema = "";
     }
 
     public void inActive() {
         this.isActive = false;
+    }
+
+    public void setEncryptedPassword(PasswordEncoder passwordEncoder) {
+        this.password = passwordEncoder.encode(password);
     }
 }

--- a/src/main/java/com/aiary/aiary/domain/user/entity/User.java
+++ b/src/main/java/com/aiary/aiary/domain/user/entity/User.java
@@ -35,6 +35,10 @@ public class User extends BaseEntity {
     @Column(length = 500)
     private String thema;   // 테마 (변경될 수 있음)
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
     @Column(name = "is_active")
     private boolean isActive = true; // 활성 여부
 
@@ -42,10 +46,11 @@ public class User extends BaseEntity {
     private List<Diary> diaries = new ArrayList<>();
 
     @Builder
-    private User(String email, String nickname, String password) {
+    private User(String email, String nickname, String password, Role role) {
         this.email = email;
         this.nickname = nickname;
         this.password = password;
+        this.role = role;
         this.thema = "";
     }
 
@@ -56,4 +61,5 @@ public class User extends BaseEntity {
     public void setEncryptedPassword(PasswordEncoder passwordEncoder) {
         this.password = passwordEncoder.encode(password);
     }
+
 }

--- a/src/main/java/com/aiary/aiary/domain/user/entity/UserDetail.java
+++ b/src/main/java/com/aiary/aiary/domain/user/entity/UserDetail.java
@@ -5,22 +5,36 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import javax.persistence.ElementCollection;
+import javax.persistence.FetchType;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class SessionUser implements UserDetails {
+public class UserDetail implements UserDetails {
     private User user;
+
+    public UserDetail(User user) {
+        this.user = user;
+    }
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Builder.Default
+    private List<String> roles = new ArrayList<>();
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-
-        return new ArrayList<>();
+        return this.roles.stream()
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/aiary/aiary/domain/user/entity/UserDetail.java
+++ b/src/main/java/com/aiary/aiary/domain/user/entity/UserDetail.java
@@ -5,15 +5,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
-
-import javax.persistence.ElementCollection;
-import javax.persistence.FetchType;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @Builder
@@ -22,19 +16,12 @@ import java.util.stream.Collectors;
 public class UserDetail implements UserDetails {
     private User user;
 
-    public UserDetail(User user) {
-        this.user = user;
-    }
-
-    @ElementCollection(fetch = FetchType.EAGER)
-    @Builder.Default
-    private List<String> roles = new ArrayList<>();
-
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return this.roles.stream()
-                .map(SimpleGrantedAuthority::new)
-                .collect(Collectors.toList());
+        Collection<GrantedAuthority> collections = new ArrayList<>();
+        collections.add(() -> "ROLE_" + user.getRole());
+
+        return collections;
     }
 
     @Override

--- a/src/main/java/com/aiary/aiary/domain/user/exception/InValidAccessException.java
+++ b/src/main/java/com/aiary/aiary/domain/user/exception/InValidAccessException.java
@@ -1,0 +1,11 @@
+package com.aiary.aiary.domain.user.exception;
+
+
+import com.aiary.aiary.global.error.ErrorCode;
+import com.aiary.aiary.global.error.exception.BusinessException;
+
+public class InValidAccessException extends BusinessException {
+    public InValidAccessException() {
+        super(ErrorCode.ACCESS_INVALID_VALUE);
+    }
+}

--- a/src/main/java/com/aiary/aiary/domain/user/exception/InValidPasswordException.java
+++ b/src/main/java/com/aiary/aiary/domain/user/exception/InValidPasswordException.java
@@ -1,0 +1,11 @@
+package com.aiary.aiary.domain.user.exception;
+
+
+import com.aiary.aiary.global.error.ErrorCode;
+import com.aiary.aiary.global.error.exception.BusinessException;
+
+public class InValidPasswordException extends BusinessException {
+    public InValidPasswordException() {
+        super(ErrorCode.INVALID_PASSWORD);
+    }
+}

--- a/src/main/java/com/aiary/aiary/domain/user/exception/UnAuthorizedAccessException.java
+++ b/src/main/java/com/aiary/aiary/domain/user/exception/UnAuthorizedAccessException.java
@@ -1,0 +1,12 @@
+package com.aiary.aiary.domain.user.exception;
+
+
+import com.aiary.aiary.global.error.exception.BusinessException;
+
+import static com.aiary.aiary.global.error.ErrorCode.UNAUTHORIZED_ACCESS_ERROR;
+
+public class UnAuthorizedAccessException extends BusinessException {
+    public UnAuthorizedAccessException() {
+        super(UNAUTHORIZED_ACCESS_ERROR);
+    }
+}

--- a/src/main/java/com/aiary/aiary/domain/user/exception/UserDuplicatedException.java
+++ b/src/main/java/com/aiary/aiary/domain/user/exception/UserDuplicatedException.java
@@ -1,0 +1,11 @@
+package com.aiary.aiary.domain.user.exception;
+
+import com.aiary.aiary.global.error.exception.BusinessException;
+
+import static com.aiary.aiary.global.error.ErrorCode.USER_EMAIL_DUPLICATED;
+
+public class UserDuplicatedException extends BusinessException {
+    public UserDuplicatedException() {
+        super(USER_EMAIL_DUPLICATED);
+    }
+}

--- a/src/main/java/com/aiary/aiary/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/aiary/aiary/domain/user/exception/UserNotFoundException.java
@@ -1,0 +1,10 @@
+package com.aiary.aiary.domain.user.exception;
+
+import com.aiary.aiary.global.error.ErrorCode;
+import com.aiary.aiary.global.error.exception.BusinessException;
+
+public class UserNotFoundException extends BusinessException {
+    public UserNotFoundException() {
+        super(ErrorCode.USER_NOT_FOUND_ERROR);
+    }
+}

--- a/src/main/java/com/aiary/aiary/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/aiary/aiary/domain/user/mapper/UserMapper.java
@@ -1,0 +1,16 @@
+package com.aiary.aiary.domain.user.mapper;
+
+import com.aiary.aiary.domain.user.dto.request.UserJoinReq;
+import com.aiary.aiary.domain.user.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserMapper {
+    public User toEntity(UserJoinReq userJoinReq) {
+        return User.builder()
+                .email(userJoinReq.getEmail())
+                .password(userJoinReq.getPassword())
+                .nickname(userJoinReq.getNickname())
+                .build();
+    }
+}

--- a/src/main/java/com/aiary/aiary/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/aiary/aiary/domain/user/mapper/UserMapper.java
@@ -1,6 +1,7 @@
 package com.aiary.aiary.domain.user.mapper;
 
 import com.aiary.aiary.domain.user.dto.request.UserJoinReq;
+import com.aiary.aiary.domain.user.entity.Role;
 import com.aiary.aiary.domain.user.entity.User;
 import org.springframework.stereotype.Component;
 
@@ -11,6 +12,7 @@ public class UserMapper {
                 .email(userJoinReq.getEmail())
                 .password(userJoinReq.getPassword())
                 .nickname(userJoinReq.getNickname())
+                .role(Role.USER)
                 .build();
     }
 }

--- a/src/main/java/com/aiary/aiary/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/aiary/aiary/domain/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.aiary.aiary.domain.user.repository;
+
+import com.aiary.aiary.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByEmail(String email);
+
+    Optional<User> findUserByEmail(String email);
+}

--- a/src/main/java/com/aiary/aiary/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/aiary/aiary/domain/user/repository/UserRepository.java
@@ -7,6 +7,5 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
-
     Optional<User> findUserByEmail(String email);
 }

--- a/src/main/java/com/aiary/aiary/domain/user/service/AuthService.java
+++ b/src/main/java/com/aiary/aiary/domain/user/service/AuthService.java
@@ -4,7 +4,7 @@ import com.aiary.aiary.domain.user.dto.request.UserLoginReq;
 import com.aiary.aiary.domain.user.dto.request.UserTokenReq;
 import com.aiary.aiary.domain.user.entity.User;
 import com.aiary.aiary.domain.user.exception.*;
-import com.aiary.aiary.domain.user.repository.UserRepository;
+import com.aiary.aiary.domain.user.validator.UserValidator;
 import com.aiary.aiary.global.jwt.JwtToken;
 import com.aiary.aiary.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -12,7 +12,6 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.util.ObjectUtils;
 
@@ -22,21 +21,22 @@ import java.util.concurrent.TimeUnit;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class LoginService {
+public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
-    private final PasswordEncoder passwordEncoder;
     private final RedisTemplate<String, Object> redisTemplate;
-    private final UserRepository userRepository;
+    private final UserValidator userValidator;
 
     public JwtToken login(UserLoginReq userLoginReq) {
-        // 로그인 시  일치하면 유저 정보 가져오기
-        User user = userRepository.findUserByEmail(userLoginReq.getEmail())
-                .orElseThrow(UserNotFoundException::new);
+//        // 로그인 시  일치하면 유저 정보 가져오기
+//        User user = userRepository.findUserByEmail(userLoginReq.getEmail())
+//                .orElseThrow(UserNotFoundException::new);
+//
+//        if (!passwordEncoder.matches(userLoginReq.getPassword(), user.getPassword())){
+//            throw new InValidPasswordException();
+//        }
+        User user = userValidator.loginUser(userLoginReq);
 
-        if (!passwordEncoder.matches(userLoginReq.getPassword(), user.getPassword())){
-            throw new InValidPasswordException();
-        }
 
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(userLoginReq.getEmail(), userLoginReq.getPassword());
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);

--- a/src/main/java/com/aiary/aiary/domain/user/service/AuthService.java
+++ b/src/main/java/com/aiary/aiary/domain/user/service/AuthService.java
@@ -28,15 +28,7 @@ public class AuthService {
     private final UserValidator userValidator;
 
     public JwtToken login(UserLoginReq userLoginReq) {
-//        // 로그인 시  일치하면 유저 정보 가져오기
-//        User user = userRepository.findUserByEmail(userLoginReq.getEmail())
-//                .orElseThrow(UserNotFoundException::new);
-//
-//        if (!passwordEncoder.matches(userLoginReq.getPassword(), user.getPassword())){
-//            throw new InValidPasswordException();
-//        }
         User user = userValidator.loginUser(userLoginReq);
-
 
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(userLoginReq.getEmail(), userLoginReq.getPassword());
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);

--- a/src/main/java/com/aiary/aiary/domain/user/service/CustomUserDetailService.java
+++ b/src/main/java/com/aiary/aiary/domain/user/service/CustomUserDetailService.java
@@ -1,0 +1,26 @@
+package com.aiary.aiary.domain.user.service;
+
+import com.aiary.aiary.domain.user.entity.SessionUser;
+import com.aiary.aiary.domain.user.entity.User;
+import com.aiary.aiary.domain.user.exception.UserNotFoundException;
+import com.aiary.aiary.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User principal = userRepository.findUserByEmail(email)
+                .orElseThrow(UserNotFoundException::new);
+
+        return new SessionUser(principal);
+    }
+}

--- a/src/main/java/com/aiary/aiary/domain/user/service/CustomUserDetailService.java
+++ b/src/main/java/com/aiary/aiary/domain/user/service/CustomUserDetailService.java
@@ -1,7 +1,7 @@
 package com.aiary.aiary.domain.user.service;
 
-import com.aiary.aiary.domain.user.entity.SessionUser;
 import com.aiary.aiary.domain.user.entity.User;
+import com.aiary.aiary.domain.user.entity.UserDetail;
 import com.aiary.aiary.domain.user.exception.UserNotFoundException;
 import com.aiary.aiary.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +21,6 @@ public class CustomUserDetailService implements UserDetailsService {
         User principal = userRepository.findUserByEmail(email)
                 .orElseThrow(UserNotFoundException::new);
 
-        return new SessionUser(principal);
+        return new UserDetail(principal);
     }
 }

--- a/src/main/java/com/aiary/aiary/domain/user/service/LoginService.java
+++ b/src/main/java/com/aiary/aiary/domain/user/service/LoginService.java
@@ -1,0 +1,28 @@
+package com.aiary.aiary.domain.user.service;
+
+import com.aiary.aiary.domain.user.repository.UserRepository;
+import com.aiary.aiary.global.jwt.JwtToken;
+import com.aiary.aiary.global.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class LoginService {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final UserRepository userRepository;
+
+    public JwtToken login(String email, String password) {
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(email, password);
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+
+        return jwtTokenProvider.generateToken(authentication);
+    }
+}

--- a/src/main/java/com/aiary/aiary/domain/user/service/LoginService.java
+++ b/src/main/java/com/aiary/aiary/domain/user/service/LoginService.java
@@ -1,12 +1,17 @@
 package com.aiary.aiary.domain.user.service;
 
+import com.aiary.aiary.domain.user.entity.User;
+import com.aiary.aiary.domain.user.exception.InValidPasswordException;
+import com.aiary.aiary.domain.user.exception.UserNotFoundException;
 import com.aiary.aiary.domain.user.repository.UserRepository;
 import com.aiary.aiary.global.jwt.JwtToken;
 import com.aiary.aiary.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -17,12 +22,33 @@ import javax.transaction.Transactional;
 public class LoginService {
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final PasswordEncoder passwordEncoder;
+    private final RedisTemplate<String, Object> redisTemplate;
     private final UserRepository userRepository;
 
     public JwtToken login(String email, String password) {
+        // 로그인 시  일치하면 유저 정보 가져오기
+        User user = userRepository.findUserByEmail(email)
+                .orElseThrow(UserNotFoundException::new);
+
+        if (!passwordEncoder.matches(password, user.getPassword())){
+            throw new InValidPasswordException();
+        }
+
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(email, password);
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+        JwtToken jwt = jwtTokenProvider.generateToken(authentication);
 
-        return jwtTokenProvider.generateToken(authentication);
+        //redis에 username을 key로 저장
+        redisTemplate.opsForValue().set("ID: " + user.getEmail(), jwt.getAccessToken(), jwtTokenProvider.getExpiration(jwt.getAccessToken()));
+
+        return jwt;
+    }
+
+    public void logout(JwtToken jwtToken) {
+        Authentication authentication = jwtTokenProvider.getAuthentication(jwtToken.getAccessToken());
+        if (redisTemplate.opsForValue().get("ID: " + authentication.getName()) != null) {
+            redisTemplate.delete("ID: " + authentication.getName()); //Token 삭제
+        }
     }
 }

--- a/src/main/java/com/aiary/aiary/domain/user/service/LoginService.java
+++ b/src/main/java/com/aiary/aiary/domain/user/service/LoginService.java
@@ -1,8 +1,8 @@
 package com.aiary.aiary.domain.user.service;
 
+import com.aiary.aiary.domain.user.dto.request.UserTokenReq;
 import com.aiary.aiary.domain.user.entity.User;
-import com.aiary.aiary.domain.user.exception.InValidPasswordException;
-import com.aiary.aiary.domain.user.exception.UserNotFoundException;
+import com.aiary.aiary.domain.user.exception.*;
 import com.aiary.aiary.domain.user.repository.UserRepository;
 import com.aiary.aiary.global.jwt.JwtToken;
 import com.aiary.aiary.global.jwt.JwtTokenProvider;
@@ -13,8 +13,10 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.util.ObjectUtils;
 
 import javax.transaction.Transactional;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @Transactional
@@ -39,16 +41,57 @@ public class LoginService {
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
         JwtToken jwt = jwtTokenProvider.generateToken(authentication);
 
-        //redis에 username을 key로 저장
-        redisTemplate.opsForValue().set("ID: " + user.getEmail(), jwt.getAccessToken(), jwtTokenProvider.getExpiration(jwt.getAccessToken()));
+        //redis 에 email 을 key 로 저장, refresh 토큰을 value 값으로 저장
+        redisTemplate.opsForValue().set("RT:" + user.getEmail(), jwt.getRefreshToken(), jwt.getRefreshTokenExpirationTime(), TimeUnit.MILLISECONDS);
 
         return jwt;
     }
 
-    public void logout(JwtToken jwtToken) {
-        Authentication authentication = jwtTokenProvider.getAuthentication(jwtToken.getAccessToken());
-        if (redisTemplate.opsForValue().get("ID: " + authentication.getName()) != null) {
-            redisTemplate.delete("ID: " + authentication.getName()); //Token 삭제
+    public void logout(UserTokenReq userTokenReq) {
+        // 로그아웃 하고 싶은 토큰이 유효한 지 먼저 검증하기
+        if (!jwtTokenProvider.validateToken(userTokenReq.getAccessToken())){
+            throw new IllegalArgumentException("로그아웃 : 유효하지 않은 토큰입니다.");
         }
+
+        // Access 토큰에서 User 정보를 가져온다
+        Authentication authentication = jwtTokenProvider.getAuthentication(userTokenReq.getAccessToken());
+
+        // redis 에서 해당 User username 으로 저장된 Refresh Token 이 있는지 여부를 확인 후에 있을 경우 삭제를 한다.
+        if (redisTemplate.opsForValue().get("RT:" + authentication.getName()) != null){
+            // Refresh 토큰 삭제
+            redisTemplate.delete("RT:" + authentication.getName());
+        }
+
+        // 해당 Access Token 유효시간을 가지고 와서 BlackList 에 저장
+        Long expiration = jwtTokenProvider.getExpiration(userTokenReq.getAccessToken());
+        redisTemplate.opsForValue().set(userTokenReq.getAccessToken(),"logout", expiration, TimeUnit.MILLISECONDS);
+    }
+
+    public JwtToken reissue(UserTokenReq userTokenReq) {
+        // Refresh Token 검증
+        if (!jwtTokenProvider.validateToken(userTokenReq.getRefreshToken())) {
+            throw new IllegalArgumentException("Refresh Token 정보가 유효하지 않습니다.");
+        }
+
+        Authentication authentication = jwtTokenProvider.getAuthentication(userTokenReq.getAccessToken());
+
+        // redis 에서 User email 을 기반으로 저장된 Refresh Token 값을 가져옵니다.
+        String refreshToken = (String)redisTemplate.opsForValue().get("RT:" + authentication.getName());
+        // (추가) 로그아웃되어 Redis 에 RefreshToken 이 존재하지 않는 경우 처리
+        if(ObjectUtils.isEmpty(refreshToken)) {
+            throw new InValidAccessException();
+        }
+        if(!refreshToken.equals(userTokenReq.getRefreshToken())) {
+            throw new UnAuthorizedAccessException();
+        }
+
+        // 새로운 토큰 생성
+        JwtToken newJwt = jwtTokenProvider.generateToken(authentication);
+
+        // RefreshToken Redis 업데이트
+        redisTemplate.opsForValue()
+                .set("RT:" + authentication.getName(), newJwt.getRefreshToken(), newJwt.getRefreshTokenExpirationTime(), TimeUnit.MILLISECONDS);
+
+        return newJwt;
     }
 }

--- a/src/main/java/com/aiary/aiary/domain/user/service/LoginService.java
+++ b/src/main/java/com/aiary/aiary/domain/user/service/LoginService.java
@@ -1,5 +1,6 @@
 package com.aiary.aiary.domain.user.service;
 
+import com.aiary.aiary.domain.user.dto.request.UserLoginReq;
 import com.aiary.aiary.domain.user.dto.request.UserTokenReq;
 import com.aiary.aiary.domain.user.entity.User;
 import com.aiary.aiary.domain.user.exception.*;
@@ -28,16 +29,16 @@ public class LoginService {
     private final RedisTemplate<String, Object> redisTemplate;
     private final UserRepository userRepository;
 
-    public JwtToken login(String email, String password) {
+    public JwtToken login(UserLoginReq userLoginReq) {
         // 로그인 시  일치하면 유저 정보 가져오기
-        User user = userRepository.findUserByEmail(email)
+        User user = userRepository.findUserByEmail(userLoginReq.getEmail())
                 .orElseThrow(UserNotFoundException::new);
 
-        if (!passwordEncoder.matches(password, user.getPassword())){
+        if (!passwordEncoder.matches(userLoginReq.getPassword(), user.getPassword())){
             throw new InValidPasswordException();
         }
 
-        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(email, password);
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(userLoginReq.getEmail(), userLoginReq.getPassword());
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
         JwtToken jwt = jwtTokenProvider.generateToken(authentication);
 

--- a/src/main/java/com/aiary/aiary/domain/user/service/UserService.java
+++ b/src/main/java/com/aiary/aiary/domain/user/service/UserService.java
@@ -1,0 +1,36 @@
+package com.aiary.aiary.domain.user.service;
+
+import com.aiary.aiary.domain.user.dto.request.UserJoinReq;
+import com.aiary.aiary.domain.user.entity.User;
+import com.aiary.aiary.domain.user.exception.UserNotFoundException;
+import com.aiary.aiary.domain.user.mapper.UserMapper;
+import com.aiary.aiary.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final UserMapper userMapper;
+
+    public boolean isDuplicatedEmail(String email) {
+        return userRepository.existsByEmail(email);
+    }
+
+    public void register(UserJoinReq userJoinReq) {
+        User user = userMapper.toEntity(userJoinReq);
+        user.setEncryptedPassword(passwordEncoder);
+        userRepository.save(user);
+    }
+
+    public User findUserById(long id) {
+        return userRepository.findById(id).orElseThrow(UserNotFoundException::new);
+    }
+
+    public User findUserByEmail(String email) {
+        return userRepository.findUserByEmail(email).orElseThrow(UserNotFoundException::new);
+    }
+}

--- a/src/main/java/com/aiary/aiary/domain/user/validator/UserValidator.java
+++ b/src/main/java/com/aiary/aiary/domain/user/validator/UserValidator.java
@@ -1,0 +1,39 @@
+package com.aiary.aiary.domain.user.validator;
+
+import com.aiary.aiary.domain.user.dto.request.UserJoinReq;
+import com.aiary.aiary.domain.user.dto.request.UserLoginReq;
+import com.aiary.aiary.domain.user.entity.User;
+import com.aiary.aiary.domain.user.exception.InValidPasswordException;
+import com.aiary.aiary.domain.user.exception.UserDuplicatedException;
+import com.aiary.aiary.domain.user.exception.UserNotFoundException;
+import com.aiary.aiary.domain.user.repository.UserRepository;
+import com.aiary.aiary.domain.user.service.UserService;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserValidator {
+    private final UserService userService;
+    private final PasswordEncoder passwordEncoder;
+    private final UserRepository userRepository;
+
+    public void isDuplicatedEmail (UserJoinReq request) {
+        if (userService.isDuplicatedEmail(request.getEmail())) {
+            throw new UserDuplicatedException();
+        }
+    }
+
+    public User loginUser (UserLoginReq request) {
+        // 로그인 시  일치하면 유저 정보 가져오기
+        User user = userRepository.findUserByEmail(request.getEmail())
+                .orElseThrow(UserNotFoundException::new);
+
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())){
+            throw new InValidPasswordException();
+        }
+        return user;
+    }
+}

--- a/src/main/java/com/aiary/aiary/global/config/RedisRepositoryConfig.java
+++ b/src/main/java/com/aiary/aiary/global/config/RedisRepositoryConfig.java
@@ -1,0 +1,36 @@
+package com.aiary.aiary.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableRedisRepositories
+public class RedisRepositoryConfig {
+    private final RedisProperties redisProperties;
+
+    // lettuce
+    // RedisConnectionFactory 인터페이스를 통해 LettuceConnectionFactory를 생성하여 반환한다.
+    // RedisProperties로 yaml에 저장한 host, post를 가지고 와서 연결한다.
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(){
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    // setKeySerializer, setValueSerializer 설정으로 redis-cli를 통해 직접 데이터를 보는게 가능하다.
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/aiary/aiary/global/config/SecurityConfig.java
+++ b/src/main/java/com/aiary/aiary/global/config/SecurityConfig.java
@@ -1,0 +1,43 @@
+package com.aiary.aiary.global.config;
+
+import com.aiary.aiary.global.jwt.JwtAuthenticationFilter;
+import com.aiary.aiary.global.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.cors().and().csrf().disable()
+//            .formLogin().disable()
+            .httpBasic().disable()
+            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            .and()
+            .authorizeRequests()
+            .antMatchers("/api/users/login").permitAll() // 회원가입, 로그인 API는 인증 없이 허용
+            .antMatchers("/api/users/join").permitAll()
+            .anyRequest().authenticated()
+            .and()
+            .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+                    UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/aiary/aiary/global/config/SecurityConfig.java
+++ b/src/main/java/com/aiary/aiary/global/config/SecurityConfig.java
@@ -21,7 +21,7 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http.cors().and().csrf().disable()
+        http.csrf().disable()
 //            .formLogin().disable()
             .httpBasic().disable()
             .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/src/main/java/com/aiary/aiary/global/config/SecurityConfig.java
+++ b/src/main/java/com/aiary/aiary/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.aiary.aiary.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -18,6 +19,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
+    private final RedisTemplate<String, Object> redisTemplate;
+
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -27,11 +30,10 @@ public class SecurityConfig {
             .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             .and()
             .authorizeRequests()
-            .antMatchers("/api/users/login").permitAll() // 회원가입, 로그인 API는 인증 없이 허용
-            .antMatchers("/api/users/join").permitAll()
+            .antMatchers("/api/users/**").permitAll() // 회원가입, 로그인, 로그아웃 API는 인증 없이 허용
             .anyRequest().authenticated()
             .and()
-            .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+            .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, redisTemplate),
                     UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }

--- a/src/main/java/com/aiary/aiary/global/config/SecurityConfig.java
+++ b/src/main/java/com/aiary/aiary/global/config/SecurityConfig.java
@@ -2,6 +2,8 @@ package com.aiary.aiary.global.config;
 
 import com.aiary.aiary.global.jwt.JwtAuthenticationFilter;
 import com.aiary.aiary.global.jwt.JwtTokenProvider;
+import com.aiary.aiary.global.jwt.exception.JwtAccessDeniedHandler;
+import com.aiary.aiary.global.jwt.exception.JwtAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,17 +22,23 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisTemplate<String, Object> redisTemplate;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http.csrf().disable()
-//            .formLogin().disable()
+        http.csrf().disable().cors().and()
+            .exceptionHandling()
+            .authenticationEntryPoint(jwtAuthenticationEntryPoint)  // 403 (권한이 없는 사용자)
+            .accessDeniedHandler(jwtAccessDeniedHandler)            // 401 (인증되지 않은 사용자)
+            .and()
             .httpBasic().disable()
             .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             .and()
             .authorizeRequests()
             .antMatchers("/api/users/**").permitAll() // 회원가입, 로그인, 로그아웃 API는 인증 없이 허용
+            .antMatchers("/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**").permitAll() // swagger 인증 없이 허용
             .anyRequest().authenticated()
             .and()
             .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, redisTemplate),

--- a/src/main/java/com/aiary/aiary/global/config/SwaggerConfig.java
+++ b/src/main/java/com/aiary/aiary/global/config/SwaggerConfig.java
@@ -5,8 +5,10 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.SpringDocUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import java.util.Collections;
 
@@ -15,6 +17,10 @@ import java.util.Collections;
 @Configuration
 @EnableWebMvc
 public class SwaggerConfig {
+    static {
+        SpringDocUtils.getConfig()
+                .addAnnotationsToIgnore(AuthenticationPrincipal.class);
+    }
     @Bean
     public OpenAPI openApi() {
         return new OpenAPI()

--- a/src/main/java/com/aiary/aiary/global/config/SwaggerConfig.java
+++ b/src/main/java/com/aiary/aiary/global/config/SwaggerConfig.java
@@ -1,11 +1,14 @@
 package com.aiary.aiary.global.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
-import org.springdoc.core.GroupedOpenApi;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import java.util.Collections;
 
 // swagger 접속 url -> http://localhost:8080/swagger-ui/index.html#/
 
@@ -13,17 +16,24 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 @EnableWebMvc
 public class SwaggerConfig {
     @Bean
-    public GroupedOpenApi publicApi() {
-        return GroupedOpenApi.builder()
-                .group("AIARY v2")
-                .pathsToMatch("/api/**")
-                .build();
-    }
-    @Bean
-    public OpenAPI springShopOpenAPI() {
+    public OpenAPI openApi() {
         return new OpenAPI()
-                .info(new Info().title("AIary API")
+                .components(new Components()
+                        .addSecuritySchemes("bearerAuth", apiKeySecuritySchema()))
+                        .security(Collections.singletonList(schemaRequirement))
+                .info(new Info().title("AIARY API")
                         .description("사용자가 작성한 일기에서 키워드를 추출하여 그림일기 그려주는 서비스")
                         .version("v2"));
     }
+
+    public SecurityScheme apiKeySecuritySchema() {
+        return new SecurityScheme()
+                .name("Authorization")
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .type(SecurityScheme.Type.HTTP);
+    }
+
+    SecurityRequirement schemaRequirement = new SecurityRequirement().addList("bearerAuth");
 }

--- a/src/main/java/com/aiary/aiary/global/entity/BaseEntity.java
+++ b/src/main/java/com/aiary/aiary/global/entity/BaseEntity.java
@@ -20,7 +20,8 @@ public abstract class BaseEntity {
 
     @LastModifiedDate
     private LocalDateTime updatedAt;
+    
     @Column(name = "is_deleted")
-    private boolean isDeleted;
+    private boolean isDeleted = false;
 }
 

--- a/src/main/java/com/aiary/aiary/global/error/ErrorCode.java
+++ b/src/main/java/com/aiary/aiary/global/error/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
   // Global
   INTERNAL_SERVER_ERROR(500, "G001", "서버 오류"),
   INPUT_INVALID_VALUE(409, "G002", "잘못된 입력"),
+  ACCESS_INVALID_VALUE(400, "G003", "잘못된 접근"),
 
   // 예시
   // User 도메인

--- a/src/main/java/com/aiary/aiary/global/error/ErrorCode.java
+++ b/src/main/java/com/aiary/aiary/global/error/ErrorCode.java
@@ -1,0 +1,25 @@
+package com.aiary.aiary.global.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/** {주체}_{이유} message 는 동사 명사형으로 마무리 */
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+  // Global
+  INTERNAL_SERVER_ERROR(500, "G001", "서버 오류"),
+  INPUT_INVALID_VALUE(409, "G002", "잘못된 입력"),
+
+  // 예시
+  // User 도메인
+  INVALID_PASSWORD(400, "U001", "잘못된 비밀번호"),
+  USER_NOT_FOUND_ERROR(400, "U002", "사용자를 찾을 수 없음"),
+  UNAUTHORIZED_ACCESS_ERROR(403, "U003", "승인되지 않은 접근"),
+  USER_EMAIL_DUPLICATED(409, "U004", "회원 아이디 중복"),
+  ;
+
+  private final int status;
+  private final String code;
+  private final String message;
+}

--- a/src/main/java/com/aiary/aiary/global/error/ErrorResponse.java
+++ b/src/main/java/com/aiary/aiary/global/error/ErrorResponse.java
@@ -1,0 +1,61 @@
+package com.aiary.aiary.global.error;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.validation.BindingResult;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ErrorResponse {
+  private String businessCode;
+  private String errorMessage;
+  private List<FieldError> errors;
+
+  private ErrorResponse(ErrorCode code, List<FieldError> fieldErrors) {
+    this.businessCode = code.getCode();
+    this.errorMessage = code.getMessage();
+    this.errors = fieldErrors;
+  }
+
+  private ErrorResponse(ErrorCode code) {
+    this.businessCode = code.getCode();
+    this.errorMessage = code.getMessage();
+    this.errors = new ArrayList<>();
+  }
+
+  public static ErrorResponse of(final ErrorCode code, final BindingResult bindingResult) {
+    return new ErrorResponse(code, FieldError.of(bindingResult));
+  }
+
+  public static ErrorResponse of(ErrorCode code) {
+    return new ErrorResponse(code);
+  }
+
+  @Getter
+  @AllArgsConstructor
+  public static class FieldError {
+    private String field;
+    private String value;
+    private String reason;
+
+    private static List<FieldError> of(final BindingResult bindingResult) {
+      final List<org.springframework.validation.FieldError> fieldErrors =
+          bindingResult.getFieldErrors();
+      return fieldErrors.stream()
+          .map(
+              error ->
+                  new FieldError(
+                      error.getField(),
+                      error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+                      error.getDefaultMessage()))
+          .collect(Collectors.toList());
+    }
+  }
+}

--- a/src/main/java/com/aiary/aiary/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/aiary/aiary/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,44 @@
+package com.aiary.aiary.global.error;
+
+import com.aiary.aiary.global.error.exception.BusinessException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static com.aiary.aiary.global.error.ErrorCode.INPUT_INVALID_VALUE;
+
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(Exception.class)
+  protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+    log.error(e.getMessage(), e);
+    ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+    return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @ExceptionHandler
+  protected ResponseEntity<ErrorResponse> handleRuntimeException(BusinessException e) {
+    final ErrorCode errorCode = e.getErrorCode();
+    final ErrorResponse response =
+        ErrorResponse.builder()
+            .errorMessage(errorCode.getMessage())
+            .businessCode(errorCode.getCode())
+            .build();
+    log.warn(e.getMessage());
+    return ResponseEntity.status(errorCode.getStatus()).body(response);
+  }
+
+  @ExceptionHandler
+  protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+      MethodArgumentNotValidException e) {
+    final ErrorResponse response = ErrorResponse.of(INPUT_INVALID_VALUE, e.getBindingResult());
+    log.warn(e.getMessage());
+    return ResponseEntity.status(INPUT_INVALID_VALUE.getStatus()).body(response);
+  }
+}

--- a/src/main/java/com/aiary/aiary/global/error/exception/BusinessException.java
+++ b/src/main/java/com/aiary/aiary/global/error/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package com.aiary.aiary.global.error.exception;
+
+import com.aiary.aiary.global.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+  private final ErrorCode errorCode;
+
+  public BusinessException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+}

--- a/src/main/java/com/aiary/aiary/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/aiary/aiary/global/jwt/JwtAuthenticationFilter.java
@@ -1,8 +1,10 @@
 package com.aiary.aiary.global.jwt;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.GenericFilterBean;
 
@@ -16,6 +18,8 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends GenericFilterBean {
     private final JwtTokenProvider jwtTokenProvider;
+    private final RedisTemplate<String, Object> redisTemplate;
+
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
@@ -24,10 +28,16 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
 
         // 토큰 유효성 검사
         if (token != null && jwtTokenProvider.validateToken(token)) {
-            // 토큰이 유효하면 토큰으로부터 유저 정보를 받아온다.
-            Authentication authentication = jwtTokenProvider.getAuthentication(token);
-            // SecurityContext 에 Authentication 객체를 저장합
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+            // Redis에 해당 accessToken logout 여부를 확인
+            String isLogout = (String) redisTemplate.opsForValue().get(token);
+
+            // 로그아웃이 없는(되어 있지 않은) 경우 해당 토큰은 정상적으로 작동하기
+            if (ObjectUtils.isEmpty(isLogout)) {
+                // 토큰이 유효하면 토큰으로부터 유저 정보를 받아온다.
+                Authentication authentication = jwtTokenProvider.getAuthentication(token);
+                // SecurityContext 에 Authentication 객체를 저장
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
         }
 
         chain.doFilter(request, response);

--- a/src/main/java/com/aiary/aiary/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/aiary/aiary/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,43 @@
+package com.aiary.aiary.global.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends GenericFilterBean {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        // 헤더에서 JWT 를 받아오기
+        String token = resolveToken((HttpServletRequest) request);
+
+        // 토큰 유효성 검사
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            // 토큰이 유효하면 토큰으로부터 유저 정보를 받아온다.
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            // SecurityContext 에 Authentication 객체를 저장합
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/aiary/aiary/global/jwt/JwtToken.java
+++ b/src/main/java/com/aiary/aiary/global/jwt/JwtToken.java
@@ -1,14 +1,11 @@
 package com.aiary.aiary.global.jwt;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Builder
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class JwtToken {
     private String grantType;
     private String accessToken;

--- a/src/main/java/com/aiary/aiary/global/jwt/JwtToken.java
+++ b/src/main/java/com/aiary/aiary/global/jwt/JwtToken.java
@@ -13,4 +13,5 @@ public class JwtToken {
     private String grantType;
     private String accessToken;
     private String refreshToken;
+    private long refreshTokenExpirationTime;
 }

--- a/src/main/java/com/aiary/aiary/global/jwt/JwtToken.java
+++ b/src/main/java/com/aiary/aiary/global/jwt/JwtToken.java
@@ -1,0 +1,14 @@
+package com.aiary.aiary.global.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+@AllArgsConstructor
+public class JwtToken {
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/aiary/aiary/global/jwt/JwtToken.java
+++ b/src/main/java/com/aiary/aiary/global/jwt/JwtToken.java
@@ -3,10 +3,12 @@ package com.aiary.aiary.global.jwt;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Builder
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class JwtToken {
     private String grantType;
     private String accessToken;

--- a/src/main/java/com/aiary/aiary/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/aiary/aiary/global/jwt/JwtTokenProvider.java
@@ -98,4 +98,18 @@ public class JwtTokenProvider {
             return false;
         }
     }
+
+    // 만료시간
+    public Long getExpiration(String accessToken) {
+        // 남은 유효시간
+        Date expiration = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(accessToken)
+                .getBody()
+                .getExpiration();
+        // 현재 시간
+        Long now = new Date().getTime();
+        return (expiration.getTime() - now);
+    }
 }

--- a/src/main/java/com/aiary/aiary/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/aiary/aiary/global/jwt/JwtTokenProvider.java
@@ -22,8 +22,8 @@ public class JwtTokenProvider {
     private final CustomUserDetailService customUserDetailService;
 
     private final Key key;
-    private long accessTokenValidTime = 30 * 60 * 1000L; // 토큰 유효시간 30분
-    private long refreshTokenValidTime = 36 * 60 * 60 * 1000L;  // 3일
+    private final long accessTokenValidTime = 30 * 60 * 1000L; // 토큰 유효시간 30분
+    private final long refreshTokenValidTime = 36 * 60 * 60 * 1000L;  // 3일
 
     // 시크릿키 초기화, secretKey를 Base64로 인코딩한다.
     public JwtTokenProvider(@Value("${jwt.secret}") String secretKey, CustomUserDetailService customUserDetailService) {
@@ -75,7 +75,11 @@ public class JwtTokenProvider {
     // 복호화
     private Claims parseClaims(String accessToken) {
         try {
-            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
         } catch (ExpiredJwtException e) {
             return e.getClaims();
         }
@@ -84,7 +88,10 @@ public class JwtTokenProvider {
     // 토큰의 유효성 + 만료일자 확인
     public boolean validateToken(String token) {
         try {
-            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
             return true;
         } catch (io.jsonwebtoken.security.SignatureException | MalformedJwtException e) {
             log.info("잘못된 JWT 서명입니다.");

--- a/src/main/java/com/aiary/aiary/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/aiary/aiary/global/jwt/JwtTokenProvider.java
@@ -21,7 +21,7 @@ public class JwtTokenProvider {
 
     private final Key key;
     private long accessTokenValidTime = 30 * 60 * 1000L; // 토큰 유효시간 30분
-    private long refreshTokenValidTime = 36 * 60 * 60 * 1000L;
+    private long refreshTokenValidTime = 36 * 60 * 60 * 1000L;  // 3일
 
     // 시크릿키 초기화, secretKey를 Base64로 인코딩한다.
     public JwtTokenProvider(@Value("${jwt.secret}") String secretKey) {

--- a/src/main/java/com/aiary/aiary/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/aiary/aiary/global/jwt/JwtTokenProvider.java
@@ -1,0 +1,101 @@
+package com.aiary.aiary.global.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Component
+public class JwtTokenProvider {
+
+    private final Key key;
+    private long accessTokenValidTime = 30 * 60 * 1000L; // 토큰 유효시간 30분
+    private long refreshTokenValidTime = 36 * 60 * 60 * 1000L;
+
+    // 시크릿키 초기화, secretKey를 Base64로 인코딩한다.
+    public JwtTokenProvider(@Value("${jwt.secret}") String secretKey) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+
+    // JWT 토큰 생성
+    public JwtToken generateToken(Authentication authentication) {
+        // 권한 가져오기
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        Date now = new Date();
+
+        // Access Token 생성
+        String accessToken = Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim("auth", authorities)
+                .setIssuedAt(now) // 토큰 발행 시간 정보
+                .setExpiration(new Date(now.getTime() + accessTokenValidTime)) // 토큰 만기
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        // Refresh Token 생성
+        String refreshToken = Jwts.builder()
+                .setExpiration(new Date(now.getTime() + refreshTokenValidTime))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        return JwtToken.builder()
+                .grantType("Bearer")
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    // JWT 토큰을 복호화하여 토큰에 들어있는 정보 조회
+    public Authentication getAuthentication(String accessToken) {
+        Claims claims = parseClaims(accessToken);
+
+        if (claims.get("auth") == null) {
+            throw new RuntimeException("권한 정보 없는 토큰입니다.");
+        }
+
+        // 권한 정보 가져오기
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get("auth").toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        //UserDetails 객체를 만들어서 Authentication 리턴
+        UserDetails userDetails = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(userDetails, "", authorities);
+    }
+
+    // 복호화
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+    // 토큰의 유효성 + 만료일자 확인
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/aiary/aiary/global/jwt/exception/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/aiary/aiary/global/jwt/exception/JwtAccessDeniedHandler.java
@@ -1,0 +1,19 @@
+package com.aiary.aiary.global.jwt.exception;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+        // 필요한 권한이 없이 접근하려 할때 403
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/src/main/java/com/aiary/aiary/global/jwt/exception/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/aiary/aiary/global/jwt/exception/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,19 @@
+package com.aiary.aiary.global.jwt.exception;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        // 유효한 자격증명을 제공하지 않고 접근하려 할때 401
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/aiary/aiary/global/result/ResultCode.java
+++ b/src/main/java/com/aiary/aiary/global/result/ResultCode.java
@@ -3,12 +3,10 @@ package com.aiary.aiary.global.result;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-/** {행위}_{목적어}_{성공여부} message 는 동사 명사형으로 마무리 */
 @Getter
 @AllArgsConstructor
 public enum ResultCode {
 
-  // 도메인 별로 나눠서 관리(ex: User 도메인)
   // user
   USER_REGISTRATION_SUCCESS("U001", "사용자 등록 성공"),
   USER_EMAIL_DUPLICATED("U002", "회원 아이디 중복"),

--- a/src/main/java/com/aiary/aiary/global/result/ResultCode.java
+++ b/src/main/java/com/aiary/aiary/global/result/ResultCode.java
@@ -12,6 +12,7 @@ public enum ResultCode {
   USER_EMAIL_NOT_DUPLICATED("U003", "회원 아이디 중복되지 않음"),
   USER_LOGIN_SUCCESS("U004", "회원 로그인 성공"),
   USER_LOGOUT_SUCCESS("U005", "회원 로그아웃 성공"),
+  USER_REISSUE_SUCCESS("U006", "토큰 재발급 성공"),
 
   // Diary
   DIARY_CREATE_SUCCESS("D001", "그림일기 등록 성공"),

--- a/src/main/java/com/aiary/aiary/global/result/ResultCode.java
+++ b/src/main/java/com/aiary/aiary/global/result/ResultCode.java
@@ -1,0 +1,23 @@
+package com.aiary.aiary.global.result;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/** {행위}_{목적어}_{성공여부} message 는 동사 명사형으로 마무리 */
+@Getter
+@AllArgsConstructor
+public enum ResultCode {
+
+  // 도메인 별로 나눠서 관리(ex: User 도메인)
+  // user
+  USER_REGISTRATION_SUCCESS("U001", "사용자 등록 성공"),
+  USER_EMAIL_DUPLICATED("U002", "회원 아이디 중복"),
+  USER_EMAIL_NOT_DUPLICATED("U003", "회원 아이디 중복되지 않음"),
+  USER_LOGIN_SUCCESS("U004", "회원 로그인 성공"),
+  USER_LOGOUT_SUCCESS("U005", "회원 로그아웃 성공"),
+
+  ;
+
+  private final String code;
+  private final String message;
+}

--- a/src/main/java/com/aiary/aiary/global/result/ResultResponse.java
+++ b/src/main/java/com/aiary/aiary/global/result/ResultResponse.java
@@ -1,0 +1,25 @@
+package com.aiary.aiary.global.result;
+
+import lombok.Getter;
+
+@Getter
+public class ResultResponse {
+
+  private String code;
+  private String message;
+  private Object data;
+
+  public static ResultResponse of(ResultCode resultCode, Object data) {
+    return new ResultResponse(resultCode, data);
+  }
+
+  public static ResultResponse of(ResultCode resultCode) {
+    return new ResultResponse(resultCode, "");
+  }
+
+  public ResultResponse(ResultCode resultCode, Object data) {
+    this.code = resultCode.getCode();
+    this.message = resultCode.getMessage();
+    this.data = data;
+  }
+}


### PR DESCRIPTION
## 📢 기능 설명 
### 로그인 (redis 에 refresh 토큰 저장)
![image](https://github.com/AI-ary/backend-spring/assets/101381901/fc351adc-6f96-4ce0-8207-b955b214dc33)

![image](https://github.com/AI-ary/backend-spring/assets/101381901/e8418cff-6eef-4c26-b8fa-4692f46bdf10)
### 로그아웃
<img width="957" alt="image" src="https://github.com/AI-ary/backend-spring/assets/101381901/6f28cea1-bee9-4500-84a1-8cb93369b343">
<br>
<br>

### 로그아웃 -> refresh 토큰 삭제 -> access 토큰을 key로 하고 value 값은 logout -> access 토큰 유효기간 끝나면 redis 에서 삭제

![image](https://github.com/AI-ary/backend-spring/assets/101381901/d152d5b4-4b20-4761-887f-2bb66c80db33)

### 유저는 토큰에 담긴 정보로 식별하도록 수정

![image](https://github.com/AI-ary/backend-spring/assets/101381901/580e9be7-aa24-4870-9ece-5e3e902f2e49)

<br>

## 연결된 issue
연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #9 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!
- [x] user에 role를 enum으로 추가했습니다. (userDetails 인터페이스를 구현하는 UserDetail 클래스에서 getAuthorities()을 Override하기 위해)
- [x] 새롭게 추가된 파일이 많습니다. 아래 참고자료 링크 추가했으니 확인 부탁드립니다!
- [x] 로그인 시 redis에 토큰 저장 후 로그아웃 요청하면 토큰 삭제되도록 구현 완료 
- [x] refresh 유효 기간동안 access 토큰 재발급 가능하도록 구현 완료
- [x] swagger 에서 JWT 인증하고 API 테스트 가능하도록 수정
- [x] 유저 식별은 토큰에 담긴 정보로 하도록 수정하였습니다. 

### 참고
https://github.com/recordbuffer/Custom-er/tree/main/src/main/java/com/shop/customer
https://gksdudrb922.tistory.com/217
https://velog.io/@joonghyun/SpringBoot-Jwt를-이용한-로그아웃

<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가? 
- [x] Approve 하기 전 확인 사항 체크했는가?